### PR TITLE
server: Add caching headers for static files

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,7 +14,6 @@ import (
 	"github.com/heathcliff26/go-wol/pkg/server/api"
 	"github.com/heathcliff26/go-wol/pkg/server/config"
 	"github.com/heathcliff26/go-wol/static"
-	"github.com/heathcliff26/simple-fileserver/pkg/filesystem"
 	"github.com/heathcliff26/simple-fileserver/pkg/middleware"
 )
 
@@ -67,16 +66,12 @@ func (s *Server) indexHandler(res http.ResponseWriter, req *http.Request) {
 
 // Starts the server and exits with error if that fails
 func (s *Server) Run() error {
-	cssFS := filesystem.NewIndexlessFilesystem(http.FS(static.CSS))
-	jsFS := filesystem.NewIndexlessFilesystem(http.FS(static.JS))
-
 	router := http.NewServeMux()
 	router.HandleFunc("GET /{$}", s.indexHandler)
 	router.HandleFunc("GET /index.html", s.indexHandler)
 	router.HandleFunc("GET /api/{macAddr}", api.Api)
-	// TODO: Add middleware to set Etag to binary version for browser caching
-	router.Handle("GET /css/", http.FileServer(cssFS))
-	router.Handle("GET /js/", http.FileServer(jsFS))
+	router.Handle("GET /css/", StaticFileServer(static.CSS))
+	router.Handle("GET /js/", StaticFileServer(static.JS))
 
 	server := http.Server{
 		Addr:    s.addr,

--- a/pkg/server/static.go
+++ b/pkg/server/static.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"embed"
+	"net/http"
+	"strings"
+
+	"github.com/heathcliff26/go-wol/pkg/version"
+	"github.com/heathcliff26/simple-fileserver/pkg/filesystem"
+)
+
+func StaticFileServer(root embed.FS) http.Handler {
+	indexlessFS := filesystem.NewIndexlessFilesystem(http.FS(root))
+	fs := http.FileServer(indexlessFS)
+
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Set("ETag", version.Version())
+		res.Header().Set("Cache-Control", "public, max-age=3600")
+
+		if match := req.Header.Get("If-None-Match"); match != "" {
+			if strings.Contains(match, version.Version()) {
+				res.WriteHeader(http.StatusNotModified)
+				return
+			}
+		}
+
+		fs.ServeHTTP(res, req)
+	})
+}

--- a/pkg/server/static_test.go
+++ b/pkg/server/static_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/heathcliff26/go-wol/pkg/version"
+	"github.com/heathcliff26/go-wol/static"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStaticFileServer(t *testing.T) {
+	t.Run("BasicRequest", func(t *testing.T) {
+		assert := assert.New(t)
+
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/css/w3.css", nil)
+
+		fs := StaticFileServer(static.CSS)
+
+		fs.ServeHTTP(res, req)
+
+		assert.Equal(version.Version(), res.Header().Get("ETag"), "Should have ETag header set")
+		assert.NotEmpty(res.Header().Get("Cache-Control"), "Should have Cache-Control header set")
+		assert.Equal(http.StatusOK, res.Code, "Should answer with Code 200")
+	})
+	t.Run("FromCache", func(t *testing.T) {
+		assert := assert.New(t)
+
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/css/w3.css", nil)
+
+		req.Header.Add("If-None-Match", version.Version())
+
+		fs := StaticFileServer(static.CSS)
+
+		fs.ServeHTTP(res, req)
+
+		assert.Equal(version.Version(), res.Header().Get("ETag"), "Should have ETag header set")
+		assert.NotEmpty(res.Header().Get("Cache-Control"), "Should have Cache-Control header set")
+		assert.Equal(http.StatusNotModified, res.Code, "Should answer with Code 304")
+	})
+	t.Run("OutdatedCache", func(t *testing.T) {
+		assert := assert.New(t)
+
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/css/w3.css", nil)
+
+		req.Header.Add("If-None-Match", "not-the-version")
+
+		fs := StaticFileServer(static.CSS)
+
+		fs.ServeHTTP(res, req)
+
+		assert.Equal(version.Version(), res.Header().Get("ETag"), "Should have ETag header set")
+		assert.NotEmpty(res.Header().Get("Cache-Control"), "Should have Cache-Control header set")
+		assert.Equal(http.StatusOK, res.Code, "Should answer with Code 200")
+	})
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"fmt"
 	"runtime"
 	"runtime/debug"
 
@@ -12,12 +11,13 @@ const Name = "go-wol"
 
 var version = "devel"
 
+// Create a new version command with the given app name
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version information and exit",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Print(Version())
+			cmd.Print(VersionInfoString())
 		},
 	}
 	// Override to prevent parent function from running
@@ -26,7 +26,13 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
+// Return the version string
 func Version() string {
+	return version
+}
+
+// Return a formated string containing the version, git commit and go version the app was compiled with.
+func VersionInfoString() string {
 	var commit string
 	buildinfo, _ := debug.ReadBuildInfo()
 	for _, item := range buildinfo.Settings {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -18,7 +18,20 @@ func TestNewVersionCommand(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	result := Version()
+	assert := assert.New(t)
+
+	oldVersion := version
+	t.Cleanup(func() {
+		version = oldVersion
+	})
+
+	version = "v0.0.0-unit-test"
+
+	assert.Equal(version, Version(), "Version should return the content of the version variable")
+}
+
+func TestVersionInfoString(t *testing.T) {
+	result := VersionInfoString()
 
 	lines := strings.Split(result, "\n")
 


### PR DESCRIPTION
Set ETag header for static files to facilitate client-side caching. Change the version logic to enable runtime access to just the version string.

Fixes: #7