### PR TITLE
Dockerfile: Fix missing data volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,12 @@ RUN GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh
 # Create final docker image
 FROM scratch AS final-stage
 
-WORKDIR /
-
 COPY --from=build-stage /app/bin/go-wol /go-wol
 
 USER 1001
+
+WORKDIR /data
+VOLUME /data
 
 ENTRYPOINT ["/go-wol"]
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ Use "go-wol [command] --help" for more information about a command.
 
 When using the container image, please note that the server needs to run with `--net host` to send the magic packets.
 ```
-$ podman run -d -net host -v /path/to/config.yaml:/config/config.yaml ghcr.io/heathcliff26/go-wol:latest
+$ podman run -d --net host -v /path/to/config.yaml:/config/config.yaml ghcr.io/heathcliff26/go-wol:latest
 ```
+If you want to use it with persistent data, run it with `-v go-wol-data:/data`. With the default configuration it will write data to `/data/hosts.yaml`.
+The image can be run without configuration, it will simply use the default values.
 
 ### Image location
 

--- a/pkg/server/storage/file/config.go
+++ b/pkg/server/storage/file/config.go
@@ -1,10 +1,7 @@
 package file
 
-import "os"
-
 const (
-	DEFAULT_FILE_PATH           = "hosts.yaml"
-	DEFAULT_FILE_PATH_CONTAINER = "/data/hosts.yaml"
+	DEFAULT_FILE_PATH = "hosts.yaml"
 )
 
 type FileBackendConfig struct {
@@ -12,11 +9,7 @@ type FileBackendConfig struct {
 }
 
 func NewDefaultFileBackendConfig() FileBackendConfig {
-	cfg := FileBackendConfig{
+	return FileBackendConfig{
 		Path: DEFAULT_FILE_PATH,
 	}
-	if _, ok := os.LookupEnv("container"); ok {
-		cfg.Path = DEFAULT_FILE_PATH_CONTAINER
-	}
-	return cfg
 }


### PR DESCRIPTION
Add a data volume to the container to ensure that it can write data.
Additionally add an explanation to the README on how to use persistent data
accross restarts.
Remove container specific default file path, as it is redundant with setting
the workdir to /data.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>