### PR TITLE
Add hostname validation

### DIFF
--- a/pkg/server/api/v1/api.go
+++ b/pkg/server/api/v1/api.go
@@ -69,6 +69,13 @@ func (h *apiHandler) AddHostHandler(res http.ResponseWriter, req *http.Request) 
 		return
 	}
 
+	if !utils.ValidateHostname(name) {
+		slog.Debug("Client send invalid hostname", slog.String("name", name))
+		res.WriteHeader(http.StatusBadRequest)
+		sendResponse(res, "Invalid hostname")
+		return
+	}
+
 	err := h.storage.AddHost(macAddr, name)
 	if err != nil {
 		slog.Error("Failed to add host", "mac", macAddr, "name", name, "error", err)

--- a/pkg/server/api/v1/api_test.go
+++ b/pkg/server/api/v1/api_test.go
@@ -85,6 +85,16 @@ func TestAddHostHandler(t *testing.T) {
 				Reason: "Invalid MAC address",
 			},
 		},
+		{
+			Name:   "InvalidHost",
+			MAC:    "00:11:22:33:44:55",
+			Host:   "Invalid-Host@not_a_domain",
+			Status: http.StatusBadRequest,
+			Response: Response{
+				Status: "error",
+				Reason: "Invalid hostname",
+			},
+		},
 	}
 
 	tmpDir := t.TempDir()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,9 +1,37 @@
 package utils
 
-import "net"
+import (
+	"net"
+	"regexp"
+	"strings"
+)
+
+var hostnameValidCharsRegexp = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$`)
 
 // ValidateMACAddress checks if the given string is a valid MAC address.
 func ValidateMACAddress(macAddrStr string) bool {
 	_, err := net.ParseMAC(macAddrStr)
 	return err == nil
+}
+
+// Validate that the given hostname is a valid domain name.
+func ValidateHostname(hostname string) bool {
+	// Hostname must be between 1 and 253 characters
+	if len(hostname) < 1 || len(hostname) > 253 {
+		return false
+	}
+
+	labels := strings.Split(hostname, ".")
+	for _, label := range labels {
+		// Each label must be between 1 and 63 characters
+		if len(label) < 1 || len(label) > 63 {
+			return false
+		}
+
+		if !hostnameValidCharsRegexp.MatchString(label) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,54 @@ func TestValidateMACAddress(t *testing.T) {
 		t.Run(tCase.name, func(t *testing.T) {
 			result := ValidateMACAddress(tCase.macAddr)
 			assert.Equalf(t, tCase.expected, result, "ValidateMACAddress(%q)", tCase.macAddr)
+		})
+	}
+}
+
+func TestValidateHostname(t *testing.T) {
+	tMatrix := []struct {
+		name     string
+		hostname string
+		expected bool
+	}{
+		{"ValidHostnameSimple", "example.com", true},
+		{"ValidHostnameWithSubdomain", "sub.example.com", true},
+		{"ValidHostnameSingleLabelMaxLength", strings.Repeat("a", 63) + ".com", true},
+		{"ValidHostnameWithNumbers", "123example.com", true},
+		{"ValidHostnameWithHyphen", "example-site.com", true},
+		{"ValidHostnameSingleLabel", "localhost", true},
+		{"ValidHostnameWithNumericTLD", "example.123", true},
+		{"ValidHostnameWithMixedCase", "ExAmPlE.cOm", true},
+		{"ValidHostnameWithMultipleSubdomains", "sub1.sub2.example.com", true},
+		{"ValidHostnameWithNumericSubdomain", "123.example.com", true},
+		{"ValidHostnameWithMaxLength", strings.Repeat("a", 63) + "." + strings.Repeat("b", 63) + "." + strings.Repeat("c", 63) + "." + strings.Repeat("d", 61), true},
+		{"ValidSingleCharacterHostname", "a", true},
+		{"InvalidHostnameSingleLabelTooLong", strings.Repeat("a", 64) + ".com", false},
+		{"InvalidHostnameEmpty", "", false},
+		{"InvalidHostnameWithSpecialChars", "example@site.com", false},
+		{"InvalidHostnameWithUnderscore", "example_site.com", false},
+		{"InvalidHostnameStartingWithHyphen", "-example.com", false},
+		{"InvalidHostnameEndingWithHyphen", "example-.com", false},
+		{"InvalidHostnameWithConsecutiveDots", "example..com", false},
+		{"InvalidHostnameWithSpaces", "example site.com", false},
+		{"InvalidHostnameWithUnicode", "exämple.com", false},
+		{"InvalidHostnameWithEmoji", "example😊.com", false},
+		{"InvalidHostnameTrailingDot", "example.com.", false},
+		{"InvalidHostnameLeadingDot", ".example.com", false},
+		{"InvalidHostnameTooLong", strings.Repeat("a", 254), false},
+	}
+
+	for _, tCase := range tMatrix {
+		t.Run(tCase.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			result := ValidateHostname(tCase.hostname)
+
+			if tCase.expected {
+				assert.True(result, "ValidateHostname(%q) should be valid", tCase.hostname)
+			} else {
+				assert.False(result, "ValidateHostname(%q) should be invalid", tCase.hostname)
+			}
 		})
 	}
 }

--- a/static/index.html
+++ b/static/index.html
@@ -55,7 +55,7 @@
                             {{end}}
                             <li class="list-group-item shadow">
                                 <form class="form-floating mb-3 needs-validation" id="custom-mac-form" onsubmit="wakeCustom(); return false;">
-                                    <input type="text" class="form-control" id="custom-mac-input" placeholder="Custom MAC" minlength="17" maxlength="17" required aria-label="Enter custom MAC address" oninput="formatAndValidateMAC(this)">
+                                    <input type="text" class="form-control" id="custom-mac-input" placeholder="Custom MAC" required aria-label="Enter custom MAC address" oninput="formatAndValidateMAC(this)">
                                     <label for="custom-mac-input">Custom MAC</label>
                                 </form>
                                 <div class="row">
@@ -96,22 +96,22 @@
                     <h5 class="modal-title" id="addHostModalTitle">Add New Host</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close dialog"></button>
                 </div>
-                <div class="modal-body" id="addHostModalBody">
-                    <form id="addHostForm">
+                <form id="addHostForm" class="needs-validation" onsubmit="addHost(); return false;">
+                    <div class="modal-body" id="addHostModalBody">
                         <div class="mb-3">
                             <label for="hostName" class="form-label">Host Name</label>
-                            <input type="text" class="form-control" id="hostName" required aria-label="The name of the new host">
+                            <input type="text" class="form-control" id="hostName" required aria-label="The name of the new host" oninput="validateHostname(this)">
                         </div>
                         <div class="mb-3">
                             <label for="macAddress" class="form-label">MAC Address</label>
-                            <input type="text" class="form-control" id="macAddress" minlength="17" maxlength="17" required aria-label="The MAC address of the new host" oninput="formatAndValidateMAC(this)">
+                            <input type="text" class="form-control" id="macAddress" required aria-label="The MAC address of the new host" oninput="formatAndValidateMAC(this)">
                         </div>
-                    </form>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close dialog">Close</button>
-                    <button type="button" class="btn btn-primary" onclick="addHost();" aria-label="Add Host">Add Host</button>
-                </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close dialog">Close</button>
+                        <button type="submit" class="btn btn-primary" aria-label="Add Host">Add Host</button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -61,11 +61,50 @@ function formatAndValidateMAC(input) {
 
     input.value = formattedValue;
 
-    // Validate the MAC address
-    const isValid = /^([0-9A-F]{2}:){5}[0-9A-F]{2}$/.test(formattedValue);
-    if (!isValid && formattedValue.length === 17) {
-        input.setCustomValidity("Invalid MAC address format");
-    } else {
+    // Pattern is already enforced by the formatting above.
+    // Only check left is the length.
+    if (formattedValue.length === 17) {
         input.setCustomValidity("");
+    } else {
+        input.setCustomValidity("MAC Address must be 17 characters long");
     }
+}
+
+function validateHostname(input) {
+    const hostname = input.value;
+
+    if (/[^a-zA-Z0-9.-]/.test(hostname)) {
+        input.setCustomValidity("Hostname can only contain letters, numbers, dots, and hyphens");
+        return;
+    }
+    if (hostname.length > 253) {
+        input.setCustomValidity("Hostname must be less than 253 characters");
+        return;
+    }
+    if (hostname.length < 1) {
+        input.setCustomValidity("Hostname cannot be empty");
+        return;
+    }
+    if (hostname.startsWith('.') || hostname.endsWith('.')) {
+        input.setCustomValidity("Hostname cannot start or end with a dot");
+        return;
+    }
+
+    const labels = hostname.split('.');
+    for (const label of labels) {
+        if (label.length > 63) {
+            input.setCustomValidity("Each label in the hostname must be less than 63 characters");
+            return;
+        }
+        if (label.length < 1) {
+            input.setCustomValidity("Each label in the hostname must be at least 1 character");
+            return;
+        }
+        if (label.startsWith('-') || label.endsWith('-')) {
+            input.setCustomValidity("Labels cannot start or end with a hyphen");
+            return;
+        }
+    }
+
+    input.setCustomValidity("");
 }


### PR DESCRIPTION
Add both server and client side hostname validation.
Hostnames should be valid domain names.
Fix MAC address client side validation not working correctly.

Notice:
This should not break existing hostnames, as they won't be validated.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>