### PR TITLE
Fix code alerts found by gosec

### DIFF
--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -103,6 +103,7 @@ func loadConfigFile(path string, env bool) (Config, error) {
 
 	p := getPath(path)
 
+	// #nosec G304 -- Local users can decide on their file path themselves.
 	f, err := os.ReadFile(p)
 	if path == "" && os.IsNotExist(err) {
 		slog.Info("No config file specified and default file does not exist, falling back to default values.", slog.String("default-path", p))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	api "github.com/heathcliff26/go-wol/pkg/server/api/v1"
 	"github.com/heathcliff26/go-wol/pkg/server/config"
@@ -65,8 +66,9 @@ func (s *Server) Run() error {
 	router.Handle("GET /js/", assetFS)
 
 	server := http.Server{
-		Addr:    s.addr,
-		Handler: middleware.Logging(router),
+		Addr:        s.addr,
+		Handler:     middleware.Logging(router),
+		ReadTimeout: 10 * time.Second,
 	}
 
 	var err error

--- a/pkg/server/storage/file/file.go
+++ b/pkg/server/storage/file/file.go
@@ -133,11 +133,12 @@ func (fb *FileBackend) GetHosts() ([]types.Host, error) {
 
 // Check if the storage backend is readonly
 func (fb *FileBackend) Readonly() (bool, error) {
+	//#nosec G302 -- The file does not contain sensitive data, so it can be world readable. Additionally final permissions are determined by the umask.
 	f, err := os.OpenFile(fb.path, os.O_RDWR, 0644)
 	if err != nil {
 		return true, nil
 	}
-	f.Close()
+	_ = f.Close()
 	return false, nil
 }
 
@@ -147,6 +148,7 @@ func (fb *FileBackend) save() error {
 		return fmt.Errorf("failed to marshal storage data: %w", err)
 	}
 
+	// #nosec G306 -- The file does not contain sensitive data, so it can be world readable. Additionally final permissions are determined by the umask.
 	err = os.WriteFile(fb.path, data, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write storage file: %w", err)

--- a/pkg/server/storage/valkey/valkey.go
+++ b/pkg/server/storage/valkey/valkey.go
@@ -34,7 +34,9 @@ func NewValkeyBackend(cfg ValkeyConfig) (*ValkeyBackend, error) {
 	var tlsConfig *tls.Config
 
 	if cfg.TLS {
-		tlsConfig = &tls.Config{}
+		tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 	}
 
 	opt := valkey.ClientOption{


### PR DESCRIPTION
Ensure that the http server has a sensible ReadTimeout. As all files and requests made or send to the server should be small, the timeout can be set for the whole request, instead of just the header.

Ensure valkey tls configuration uses sensible minimum TLS version.

Fix missing error return by ignoring it.
Add #nosec comments with justification where appropiate.