### PR TITLE
Makefile: Move target description to above them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,45 +4,59 @@ REPOSITORY ?= localhost
 CONTAINER_NAME ?= go-wol
 TAG ?= latest
 
-build: ## Build the binary
+# Build the binary
+build:
 	hack/build.sh
 
-run: build ## Run the server on port 8080 to quickly test changes
+# Run the server on port 8080 to quickly test changes
+run: build
 	bin/go-wol server --log debug
 
-image: ## Build the container image
+# Build the container image
+image:
 	podman build -t $(REPOSITORY)/$(CONTAINER_NAME):$(TAG) .
 
-test: ## Run unit-tests with race detection and coverage
+# Run unit-tests with race detection and coverage
+test:
 	go test -v -race -coverprofile=coverprofile.out -coverpkg "./..." ./...
 
-update-deps: ## Update project dependencies
+# Update project dependencies
+update-deps:
 	hack/update-deps.sh
 
-coverprofile: ## Generate coverage profile
+# Generate coverage profile
+coverprofile:
 	hack/coverprofile.sh
 
-lint: ## Run linter
+# Run linter
+lint:
 	golangci-lint run -v
 
-fmt: ## Format the code
+# Format the code
+fmt:
 	gofmt -s -w ./cmd ./pkg
 
-validate: ## Validate that all generated files are up to date.
+# Validate that all generated files are up to date.
+validate:
 	hack/validate.sh
 
-generate-bootstrap: ## Generate the bootstrap.css file
+# Generate the bootstrap.css file
+generate-bootstrap:
 	hack/generate-bootstrap.sh
 
-gosec: ## Scan code for vulnerabilities using gosec
+# Scan code for vulnerabilities using gosec
+gosec:
 	gosec ./...
 
-clean: ## Clean up generated files
+# Clean up generated files
+clean:
 	rm -rf bin coverprofiles coverprofile.out
 
-help: ## Show this help message
+# Show this help message
+help:
 	@echo "Available targets:"
-	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
+	@echo ""
+	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' $(MAKEFILE_LIST) | column -s: -t
 	@echo ""
 	@echo "Run 'make <target>' to execute a specific target."
 


### PR DESCRIPTION
To improve readability and maintainability, move the descriptions used by make
help to the top of their targets.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>