### PR TITLE
CI: Tag release to ensure correct version in binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
       draft:
         description: "Create draft release"
         type: boolean
-        default: false
+        default: true
       update:
         description: "Update existing release"
         type: boolean
@@ -20,10 +20,24 @@ on:
         description: "Tag container as latest"
         type: boolean
         default: true
+      prerelease:
+        description: "Mark the release as a prerelease"
+        type: boolean
+        default: false
 
 jobs:
+  tag:
+    uses: heathcliff26/ci/.github/workflows/tag.yaml@main
+    permissions:
+      contents: write
+    with:
+      tag: ${{ inputs.tag }}
+      overwrite: ${{ inputs.update }}
+    secrets: inherit
+
   build:
     uses: ./.github/workflows/ci.yaml
+    needs: tag
     permissions:
       contents: read
       packages: write
@@ -44,3 +58,4 @@ jobs:
       tag: ${{ inputs.tag }}
       release-artifacts: "release/*"
       artifacts: "go-wol-*"
+      prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
Ensure the binary get's compiled with the correct version information by
creating the tag first.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>