### PR TITLE
Add automatically generated Swagger API documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,16 @@ fmt:
 validate:
 	hack/validate.sh
 
+# Generate all required files
+generate: generate-bootstrap generate-swagger
+
 # Generate the bootstrap.css file
 generate-bootstrap:
 	hack/generate-bootstrap.sh
+
+# Generate Swagger documentation
+generate-swagger:
+	hack/swagger.sh
 
 # Scan code for vulnerabilities using gosec
 gosec:
@@ -70,7 +77,9 @@ help:
 	lint \
 	fmt \
 	validate \
+	generate \
 	generate-bootstrap \
+	generate-swagger \
 	gosec \
 	clean \
 	help \

--- a/hack/swagger.sh
+++ b/hack/swagger.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
+
+pushd "${base_dir}" >/dev/null
+
+if ! [ -e "${base_dir}/bin/swag" ]; then
+    export GOBIN="${base_dir}/bin"
+    echo "Installing swag tool"
+    go install github.com/swaggo/swag/cmd/swag@latest
+
+    echo ""
+fi
+
+export swag="${base_dir}/bin/swag"
+
+echo "Generating Swagger documentation"
+"${swag}" init -g api.go --dir pkg/server/api/v1/ -o ./ --ot yaml
+
+echo ""
+
+echo "Formatting swagger comments"
+"${swag}" fmt -g api.go --dir pkg/server/api/v1/
+
+popd >/dev/null

--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -22,6 +22,15 @@ if [ $rc -ne 0 ]; then
     exit 1
 fi
 
+echo "Check if the swagger docs are generated"
+make generate-swagger
+rc=0
+git update-index --refresh && git diff-index --quiet HEAD -- || rc=1
+if [ $rc -ne 0 ]; then
+    echo "FATAL: Need to run \"make generate-swagger\""
+    exit 1
+fi
+
 echo "All files are up to date"
 
 if grep "/bootstrap/" "${base_dir}/static/index.html"; then

--- a/pkg/server/api/v1/api.go
+++ b/pkg/server/api/v1/api.go
@@ -1,5 +1,15 @@
 package v1
 
+//	@title			go-wol API
+//	@version		1.0
+//	@description	Manage known hosts and send magic packets.
+
+//	@license.name	Apache 2.0
+//	@license.url	http://www.apache.org/licenses/LICENSE-2.0.html
+
+//	@BasePath	/api/v1
+//	@produce	json
+
 import (
 	"encoding/json"
 	"log/slog"
@@ -31,8 +41,15 @@ func NewRouter(storage *storage.Storage) *http.ServeMux {
 	return router
 }
 
-// GET /wake/{macAddr}
-// Send a magic packet to the specified MAC address
+// @Summary		Wake up host
+// @Description	Send a magic packet to the specified MAC address
+//
+// @Produce		json
+// @Param			macAddr	path		string		true	"MAC address of the host"
+// @Success		200		{object}	Response	"ok"
+// @Failure		400		{object}	Response	"Invalid MAC address"
+// @Failure		500		{object}	Response	"Failed to send magic packet"
+// @Router			/wake/{macAddr} [get]
 func WakeHandler(res http.ResponseWriter, req *http.Request) {
 	macAddr := req.PathValue("macAddr")
 
@@ -47,7 +64,7 @@ func WakeHandler(res http.ResponseWriter, req *http.Request) {
 	err = packet.Send("")
 	if err != nil {
 		slog.Info("Failed to send magic packet", slog.String("mac", macAddr), slog.Any("error", err))
-		res.WriteHeader(http.StatusBadRequest)
+		res.WriteHeader(http.StatusInternalServerError)
 		sendResponse(res, "Failed to send magic packet")
 		return
 	}
@@ -56,8 +73,16 @@ func WakeHandler(res http.ResponseWriter, req *http.Request) {
 	sendResponse(res, "")
 }
 
-// PUT /hosts/{macAddr}/{name}
-// Add a host to the storage
+// @Summary		Add new host
+// @Description	Add a new host to the known hosts
+//
+// @Produce		json
+// @Param			macAddr	path		string		true	"MAC address of the host"
+// @Param			name	path		string		true	"Name of the host"
+// @Success		200		{object}	Response	"ok"
+// @Failure		400		{object}	Response	"Invalid MAC address or hostname"
+// @Failure		500		{object}	Response	"Failed to add host"
+// @Router			/hosts/{macAddr}/{name} [put]
 func (h *apiHandler) AddHostHandler(res http.ResponseWriter, req *http.Request) {
 	macAddr := req.PathValue("macAddr")
 	name := req.PathValue("name")
@@ -88,8 +113,15 @@ func (h *apiHandler) AddHostHandler(res http.ResponseWriter, req *http.Request) 
 	sendResponse(res, "")
 }
 
-// DELETE /hosts/{macAddr}
-// Remove a host from the storage
+// @Summary		Remove host
+// @Description	Remove a host from the list of known hosts
+//
+// @Produce		json
+// @Param			macAddr	path		string		true	"MAC address of the host"
+// @Success		200		{object}	Response	"ok"
+// @Failure		400		{object}	Response	"Invalid MAC address"
+// @Failure		500		{object}	Response	"Failed to remove host"
+// @Router			/hosts/{macAddr} [delete]
 func (h *apiHandler) RemoveHostHandler(res http.ResponseWriter, req *http.Request) {
 	macAddr := req.PathValue("macAddr")
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,0 +1,101 @@
+basePath: /api/v1
+definitions:
+  v1.Response:
+    properties:
+      reason:
+        type: string
+      status:
+        type: string
+    type: object
+info:
+  contact: {}
+  description: Manage known hosts and send magic packets.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  title: go-wol API
+  version: "1.0"
+paths:
+  /hosts/{macAddr}:
+    delete:
+      description: Remove a host from the list of known hosts
+      parameters:
+      - description: MAC address of the host
+        in: path
+        name: macAddr
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "400":
+          description: Invalid MAC address
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "500":
+          description: Failed to remove host
+          schema:
+            $ref: '#/definitions/v1.Response'
+      summary: Remove host
+  /hosts/{macAddr}/{name}:
+    put:
+      description: Add a new host to the known hosts
+      parameters:
+      - description: MAC address of the host
+        in: path
+        name: macAddr
+        required: true
+        type: string
+      - description: Name of the host
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "400":
+          description: Invalid MAC address or hostname
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "500":
+          description: Failed to add host
+          schema:
+            $ref: '#/definitions/v1.Response'
+      summary: Add new host
+  /wake/{macAddr}:
+    get:
+      description: Send a magic packet to the specified MAC address
+      parameters:
+      - description: MAC address of the host
+        in: path
+        name: macAddr
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "400":
+          description: Invalid MAC address
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "500":
+          description: Failed to send magic packet
+          schema:
+            $ref: '#/definitions/v1.Response'
+      summary: Wake up host
+produces:
+- application/json
+swagger: "2.0"


### PR DESCRIPTION
Automatically generate the Swagger API documentation.
Ensure that the `swag` tool is installed in the project directory and not
globally.
Add the swag comments to api.go for generating the documentation.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>