### PR TITLE
api: Return 403 forbidden when changing hosts in readonly

### DIFF
--- a/pkg/server/api/v1/api_test.go
+++ b/pkg/server/api/v1/api_test.go
@@ -64,6 +64,7 @@ func TestWakeHandler(t *testing.T) {
 func TestAddHostHandler(t *testing.T) {
 	tMatrix := []struct {
 		Name, MAC, Host string
+		Readonly        bool
 		Status          int
 		Response        Response
 	}{
@@ -96,6 +97,17 @@ func TestAddHostHandler(t *testing.T) {
 				Reason: "Invalid hostname",
 			},
 		},
+		{
+			Name:     "ReadonlyStorage",
+			MAC:      "00:11:22:33:44:55",
+			Host:     "TestHost",
+			Readonly: true,
+			Status:   http.StatusForbidden,
+			Response: Response{
+				Status: "error",
+				Reason: "Storage is readonly",
+			},
+		},
 	}
 
 	tmpDir := t.TempDir()
@@ -109,6 +121,7 @@ func TestAddHostHandler(t *testing.T) {
 				File: file.FileBackendConfig{
 					Path: tmpDir + "/" + tCase.Name + "-hosts.yaml",
 				},
+				Readonly: tCase.Readonly,
 			}
 			storageBackend, err := storage.NewStorage(cfg)
 			require.NoError(t, err, "Should create file backend without error")
@@ -136,6 +149,7 @@ func TestAddHostHandler(t *testing.T) {
 func TestRemoveHostHandler(t *testing.T) {
 	tMatrix := []struct {
 		Name, MAC string
+		Readonly  bool
 		Status    int
 		Response  Response
 	}{
@@ -156,6 +170,16 @@ func TestRemoveHostHandler(t *testing.T) {
 				Reason: "Invalid MAC address",
 			},
 		},
+		{
+			Name:     "ReadonlyStorage",
+			MAC:      "00:11:22:33:44:55",
+			Readonly: true,
+			Status:   http.StatusForbidden,
+			Response: Response{
+				Status: "error",
+				Reason: "Storage is readonly",
+			},
+		},
 	}
 
 	tmpDir := t.TempDir()
@@ -169,6 +193,7 @@ func TestRemoveHostHandler(t *testing.T) {
 				File: file.FileBackendConfig{
 					Path: tmpDir + "/" + tCase.Name + "-hosts.yaml",
 				},
+				Readonly: tCase.Readonly,
 			}
 			storageBackend, err := storage.NewStorage(cfg)
 			require.NoError(t, err, "Should create file backend without error")

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -36,6 +36,10 @@ paths:
           description: Invalid MAC address
           schema:
             $ref: '#/definitions/v1.Response'
+        "403":
+          description: Storage is readonly
+          schema:
+            $ref: '#/definitions/v1.Response'
         "500":
           description: Failed to remove host
           schema:
@@ -64,6 +68,10 @@ paths:
             $ref: '#/definitions/v1.Response'
         "400":
           description: Invalid MAC address or hostname
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "403":
+          description: Storage is readonly
           schema:
             $ref: '#/definitions/v1.Response'
         "500":


### PR DESCRIPTION
Adding or removing hosts is not possible in readonly mode. Return 403 instead of waiting for a write error.