### PR TITLE
storage: Always render index.html instead of server side caching

### DIFF
--- a/pkg/server/api/v1/api.go
+++ b/pkg/server/api/v1/api.go
@@ -84,9 +84,9 @@ func WakeHandler(res http.ResponseWriter, req *http.Request) {
 func (h *apiHandler) GetHostsHandler(res http.ResponseWriter, req *http.Request) {
 	hosts, err := h.storage.GetHosts()
 	if err != nil {
-		slog.Error("Failed fetch hosts", "error", err)
+		slog.Error("Failed to fetch hosts", "error", err)
 		res.WriteHeader(http.StatusInternalServerError)
-		sendResponse(res, "Failed to fetch host")
+		sendResponse(res, "Failed to fetch hosts")
 		return
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,7 +36,13 @@ func NewServer(cfgServer config.ServerConfig, cfgStorage storage.StorageConfig) 
 }
 
 func (s *Server) indexHandler(res http.ResponseWriter, req *http.Request) {
-	indexHTML, indexChecksum := s.storage.GetIndexHTML()
+	indexHTML, indexChecksum, err := s.storage.GetIndexHTML()
+	if err != nil {
+		slog.Error("Failed to get index.html", "err", err)
+		http.Error(res, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
 	res.Header().Set("ETag", indexChecksum)
 	res.Header().Set("Cache-Control", "public, max-age=300")
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -32,10 +32,11 @@ func TestNewServer(t *testing.T) {
 	require.NoError(err, "Should create new server")
 	require.NotNil(s, "Server should not be empty")
 
-	indexHTML, indexChecksum := s.storage.GetIndexHTML()
-
 	assert.Equal(":8080", s.addr, "Server should have address set")
 	assert.Equal(cfgServer.SSL, s.ssl, "Server should have SSL Config")
+
+	indexHTML, indexChecksum, err := s.storage.GetIndexHTML()
+	require.NoError(err, "Should create index.html")
 
 	assert.Contains(indexHTML, "testName", "Should add hostname to index.html")
 	assert.Contains(indexHTML, "TESTMAC", "Should add MAC to index.html")
@@ -83,7 +84,8 @@ func TestServer(t *testing.T) {
 	t.Run("IndexHandler", func(t *testing.T) {
 		assert := assert.New(t)
 
-		indexHTML, indexChecksum := s.storage.GetIndexHTML()
+		indexHTML, indexChecksum, err := s.storage.GetIndexHTML()
+		require.NoError(t, err, "Should get index.html")
 
 		for _, path := range []string{"/", "/index.html"} {
 			res, err := http.Get(address + path)

--- a/pkg/server/storage/storage_test.go
+++ b/pkg/server/storage/storage_test.go
@@ -60,8 +60,6 @@ func TestNewStorage(t *testing.T) {
 		assert.NotNil(s)
 		assert.IsType(&file.FileBackend{}, s.backend, "Should have file as backend type")
 		assert.Equal(cfg.Readonly, s.readonly, "Readonly should match config")
-		assert.NotEmpty(s.indexHTML, "Index HTML should not be empty")
-		assert.NotEmpty(s.indexChecksum, "Index checksum should not be empty")
 	})
 
 	t.Run("ValkeyBackend", func(t *testing.T) {
@@ -82,8 +80,6 @@ func TestNewStorage(t *testing.T) {
 		assert.NoError(err, "Should not return an error")
 		assert.NotNil(s, "Storage should not be nil")
 		assert.IsType(&valkey.ValkeyBackend{}, s.backend, "Should have valkey as backend type")
-		assert.NotEmpty(s.indexHTML, "Index HTML should not be empty")
-		assert.NotEmpty(s.indexChecksum, "Index checksum should not be empty")
 	})
 
 	t.Run("UnknownBackend", func(t *testing.T) {
@@ -207,19 +203,6 @@ func TestNewStorage(t *testing.T) {
 	})
 }
 
-func TestStorageGetIndexHTML(t *testing.T) {
-	assert := assert.New(t)
-
-	s := &Storage{
-		indexHTML:     "<html>Test</html>",
-		indexChecksum: "1234567890abcdef",
-	}
-
-	html, checksum := s.GetIndexHTML()
-	assert.Equal(s.indexHTML, html, "HTML should match")
-	assert.Equal(s.indexChecksum, checksum, "Checksum should match")
-}
-
 func TestStorageReadonly(t *testing.T) {
 	assert := assert.New(t)
 
@@ -254,12 +237,9 @@ func TestStorageAddHost(t *testing.T) {
 
 		s.readonly = false
 		mockBackend.On("AddHost", "00:11:22:33:44:55", "test").Return(nil)
-		mockBackend.On("GetHosts").Return([]types.Host{{MAC: "00:11:22:33:44:55", Name: "test"}}, nil)
 
 		err := s.AddHost("00:11:22:33:44:55", "test")
 		assert.NoError(err, "Should add host without error")
-		assert.NotEmpty(s.indexHTML, "Should have updated index HTML")
-		assert.NotEmpty(s.indexChecksum, "Should have updated index checksum")
 		mockBackend.AssertExpectations(t)
 	})
 }
@@ -285,12 +265,9 @@ func TestStorageRemoveHost(t *testing.T) {
 
 		s.readonly = false
 		mockBackend.On("RemoveHost", "00:11:22:33:44:55").Return(nil)
-		mockBackend.On("GetHosts").Return([]types.Host{}, nil)
 
 		err := s.RemoveHost("00:11:22:33:44:55")
 		assert.NoError(err, "Should remove host without error")
-		assert.NotEmpty(s.indexHTML, "Should have updated index HTML")
-		assert.NotEmpty(s.indexChecksum, "Should have updated index checksum")
 		mockBackend.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
When running multiple instances, they are not aware of changes to the hosts.
As such the index.html needs to be rendered on each request.

Fixes: #82

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>