### PR TITLE
Add address to host attributes

### DIFF
--- a/examples/hosts.yaml
+++ b/examples/hosts.yaml
@@ -3,5 +3,6 @@ hosts:
   # They are in the same order as they will be displayed in the UI.
   - name: laptop # Freely chosen name
     mac: AA:BB:CC:DD:EE:FF  # Replace with the actual MAC address
+    address: 127.0.0.1 # (Optional) IP/DNS address of the host. Used to check if the host is online.
   - name: server # Freely chosen name
     mac: 11:22:33:44:55:66  # Replace with the actual MAC address

--- a/pkg/server/api/v1/api.go
+++ b/pkg/server/api/v1/api.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 
 	"github.com/heathcliff26/go-wol/pkg/server/storage"
+	"github.com/heathcliff26/go-wol/pkg/server/storage/types"
 	"github.com/heathcliff26/go-wol/pkg/utils"
 	"github.com/heathcliff26/go-wol/pkg/wol"
 )
@@ -129,7 +130,11 @@ func (h *apiHandler) AddHostHandler(res http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	err := h.storage.AddHost(macAddr, name)
+	host := types.Host{
+		MAC:  macAddr,
+		Name: name,
+	}
+	err := h.storage.AddHost(host)
 	if err != nil {
 		slog.Error("Failed to add host", "mac", macAddr, "name", name, "error", err)
 		res.WriteHeader(http.StatusInternalServerError)

--- a/pkg/server/storage/file/file.go
+++ b/pkg/server/storage/file/file.go
@@ -74,19 +74,19 @@ func NewFileBackend(cfg FileBackendConfig) (*FileBackend, error) {
 
 // Add a new host, overwrite existing host name if it already exists.
 // Ensures that the MAC address is unique and uppercase.
-func (fb *FileBackend) AddHost(mac string, name string) error {
+func (fb *FileBackend) AddHost(host types.Host) error {
 	fb.lock.Lock()
 	defer fb.lock.Unlock()
 
-	uppercaseMAC := strings.ToUpper(mac)
-	for i, host := range fb.storage.Hosts {
-		if host.MAC == uppercaseMAC {
-			fb.storage.Hosts[i].Name = name
+	host.MAC = strings.ToUpper(host.MAC)
+	for i, h := range fb.storage.Hosts {
+		if h.MAC == host.MAC {
+			fb.storage.Hosts[i] = host
 			return fb.save()
 		}
 	}
 
-	fb.storage.Hosts = append(fb.storage.Hosts, types.Host{MAC: uppercaseMAC, Name: name})
+	fb.storage.Hosts = append(fb.storage.Hosts, host)
 	return fb.save()
 }
 
@@ -106,17 +106,17 @@ func (fb *FileBackend) RemoveHost(mac string) error {
 }
 
 // Return the host name for a given MAC address, return empty if not found
-func (fb *FileBackend) GetHost(mac string) (string, error) {
+func (fb *FileBackend) GetHost(mac string) (types.Host, error) {
 	fb.lock.RLock()
 	defer fb.lock.RUnlock()
 
 	uppercaseMAC := strings.ToUpper(mac)
 	for _, host := range fb.storage.Hosts {
 		if host.MAC == uppercaseMAC {
-			return host.Name, nil
+			return host, nil
 		}
 	}
-	return "", nil
+	return types.Host{}, nil
 }
 
 // Return all hosts

--- a/pkg/server/storage/file/file.go
+++ b/pkg/server/storage/file/file.go
@@ -50,13 +50,14 @@ func NewFileBackend(cfg FileBackendConfig) (*FileBackend, error) {
 	changed := false
 	for _, host := range fb.storage.Hosts {
 		uppercaseMAC := strings.ToUpper(host.MAC)
-		if !macSet[uppercaseMAC] {
-			macSet[uppercaseMAC] = true
-			uniqueHosts = append(uniqueHosts, types.Host{MAC: uppercaseMAC, Name: host.Name})
-		} else {
+		if host.MAC != uppercaseMAC {
 			changed = true
 		}
-		if host.MAC != uppercaseMAC {
+		if !macSet[uppercaseMAC] {
+			macSet[uppercaseMAC] = true
+			host.MAC = uppercaseMAC
+			uniqueHosts = append(uniqueHosts, host)
+		} else {
 			changed = true
 		}
 	}

--- a/pkg/server/storage/file/file_test.go
+++ b/pkg/server/storage/file/file_test.go
@@ -119,6 +119,25 @@ func TestNewFileBackend(t *testing.T) {
 		assert.Nil(fb, "File backend should be nil")
 		assert.Contains(err.Error(), "failed to save storage file after ensuring unique, uppercase MAC addresses:", "Error should contain message")
 	})
+
+	t.Run("OptionalAttributes", func(t *testing.T) {
+		assert := assert.New(t)
+		path := "testdata/optional.yaml"
+
+		fb, err := NewFileBackend(FileBackendConfig{Path: path})
+		require.NoError(t, err, "Failed to create file backend")
+		assert.NotNil(fb, "File backend should not be nil")
+
+		hosts := append([]types.Host{}, basicTestHosts...)
+		hosts = append(hosts, types.Host{
+			Name:    "TestHost3",
+			MAC:     "77:88:99:AA:BB:CC",
+			Address: "host3.example.org",
+		})
+
+		assert.Equal(path, fb.path, "File backend path should match")
+		assert.Equal(hosts, fb.storage.Hosts, "File backend hosts should match")
+	})
 }
 
 func TestReadonly(t *testing.T) {

--- a/pkg/server/storage/file/testdata/optional.yaml
+++ b/pkg/server/storage/file/testdata/optional.yaml
@@ -1,0 +1,9 @@
+---
+hosts:
+  - name: TestHost1
+    mac: AA:BB:CC:DD:EE:FF
+  - name: TestHost2
+    mac: 11:22:33:44:55:66
+  - name: TestHost3
+    mac: 77:88:99:AA:BB:CC
+    address: host3.example.org

--- a/pkg/server/storage/storage.go
+++ b/pkg/server/storage/storage.go
@@ -67,7 +67,7 @@ func NewStorage(cfg StorageConfig) (*Storage, error) {
 
 		for _, host := range seededHosts.Hosts {
 			slog.Debug("Adding seeded host", "mac", host.MAC, "name", host.Name)
-			err := s.backend.AddHost(host.MAC, host.Name)
+			err := s.backend.AddHost(host)
 			if err != nil {
 				return nil, fmt.Errorf("failed to add seeded host '%s': %w", host.MAC, err)
 			}
@@ -131,12 +131,12 @@ func (s *Storage) GetHosts() ([]types.Host, error) {
 }
 
 // Add a new host and update the index.html
-func (s *Storage) AddHost(mac, host string) error {
+func (s *Storage) AddHost(host types.Host) error {
 	if s.readonly {
 		return fmt.Errorf("storage is readonly")
 	}
 
-	err := s.backend.AddHost(mac, host)
+	err := s.backend.AddHost(host)
 	if err != nil {
 		return fmt.Errorf("failed to add host: %w", err)
 	}

--- a/pkg/server/storage/storage_test.go
+++ b/pkg/server/storage/storage_test.go
@@ -18,8 +18,8 @@ type MockBackend struct {
 	types.StorageBackend
 }
 
-func (m *MockBackend) AddHost(mac, host string) error {
-	args := m.Called(mac, host)
+func (m *MockBackend) AddHost(host types.Host) error {
+	args := m.Called(host)
 	return args.Error(0)
 }
 
@@ -28,9 +28,9 @@ func (m *MockBackend) RemoveHost(mac string) error {
 	return args.Error(0)
 }
 
-func (m *MockBackend) GetHost(mac string) (string, error) {
+func (m *MockBackend) GetHost(mac string) (types.Host, error) {
 	args := m.Called(mac)
-	return args.String(0), args.Error(1)
+	return args.Get(0).(types.Host), args.Error(1)
 }
 
 func (m *MockBackend) GetHosts() ([]types.Host, error) {
@@ -227,7 +227,7 @@ func TestStorageAddHost(t *testing.T) {
 		assert := assert.New(t)
 
 		s.readonly = true
-		err := s.AddHost("00:11:22:33:44:55", "test")
+		err := s.AddHost(types.Host{MAC: "00:11:22:33:44:55", Name: "test"})
 		assert.Error(err)
 		assert.Contains(err.Error(), "storage is readonly")
 	})
@@ -236,9 +236,9 @@ func TestStorageAddHost(t *testing.T) {
 		assert := assert.New(t)
 
 		s.readonly = false
-		mockBackend.On("AddHost", "00:11:22:33:44:55", "test").Return(nil)
+		mockBackend.On("AddHost", types.Host{MAC: "00:11:22:33:44:55", Name: "test"}).Return(nil)
 
-		err := s.AddHost("00:11:22:33:44:55", "test")
+		err := s.AddHost(types.Host{MAC: "00:11:22:33:44:55", Name: "test"})
 		assert.NoError(err, "Should add host without error")
 		mockBackend.AssertExpectations(t)
 	})

--- a/pkg/server/storage/testsuite/basic.go
+++ b/pkg/server/storage/testsuite/basic.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/heathcliff26/go-wol/pkg/server/storage/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +15,7 @@ func RunStorageBackendTests(t *testing.T, factory StorageBackendFactory) {
 	t.Run("AddHost", func(t *testing.T) {
 		backend := factory(t, "add-host")
 
-		err := backend.AddHost(testHosts[0].MAC, testHosts[0].Name)
+		err := backend.AddHost(testHosts[0])
 		require.NoError(t, err, "AddHost failed")
 	})
 
@@ -24,7 +25,7 @@ func RunStorageBackendTests(t *testing.T, factory StorageBackendFactory) {
 
 		host, err := backend.GetHost(testHosts[0].MAC)
 		require.NoError(t, err, "GetHost failed")
-		assert.Equal(t, testHosts[0].Name, host, "Failed to retrieve host")
+		assert.Equal(t, testHosts[0], host, "Failed to retrieve host")
 	})
 
 	t.Run("RemoveHost", func(t *testing.T) {
@@ -80,13 +81,13 @@ func RunStorageBackendTests(t *testing.T, factory StorageBackendFactory) {
 		require := require.New(t)
 		backend := factory(t, "case-insensitive-mac")
 
-		err := backend.AddHost("aa:bb:cc:dd:ee:ff", "LowerCase")
+		err := backend.AddHost(types.Host{MAC: "aa:bb:cc:dd:ee:ff", Name: "LowerCase"})
 
 		require.NoError(err, "Should add host")
 
 		host, err := backend.GetHost("AA:BB:CC:dd:ee:ff")
 		require.NoError(err, "Should get host regardless of case")
-		assert.Equal("LowerCase", host, "Should get correct host name")
+		assert.Equal("LowerCase", host.Name, "Should get correct host name")
 
 		hosts, err := backend.GetHosts()
 		require.NoError(err, "Should get hosts")
@@ -101,10 +102,12 @@ func RunStorageBackendTests(t *testing.T, factory StorageBackendFactory) {
 		require := require.New(t)
 		backend := factory(t, "add-host-overwrite")
 
-		err := backend.AddHost(testHosts[0].MAC, testHosts[0].Name)
+		err := backend.AddHost(testHosts[0])
 		require.NoError(err, "Should add host")
 
-		err = backend.AddHost(testHosts[0].MAC, "NewName")
+		host := testHosts[0]
+		host.Name = "NewName"
+		err = backend.AddHost(host)
 		require.NoError(err, "Should overwrite host")
 
 		hosts, err := backend.GetHosts()
@@ -119,7 +122,9 @@ func RunStorageBackendTests(t *testing.T, factory StorageBackendFactory) {
 		backend := factory(t, "host-overwrite-keep-order")
 		addHosts(t, backend)
 
-		err := backend.AddHost(testHosts[0].MAC, "NewName")
+		testHost := testHosts[0]
+		testHost.Name = "NewName"
+		err := backend.AddHost(testHost)
 		require.NoError(err, "Should overwrite host")
 
 		hosts, err := backend.GetHosts()

--- a/pkg/server/storage/testsuite/race.go
+++ b/pkg/server/storage/testsuite/race.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+
+	"github.com/heathcliff26/go-wol/pkg/server/storage/types"
 )
 
 // These tests do not run any checks themselves, they rely on race detection for that.
@@ -21,7 +23,10 @@ func RunStorageBackendRaceTests(t *testing.T, factory StorageBackendFactory) {
 
 				mac := fmt.Sprintf("AA:BB:CC:DD:EE:%02X", i)
 				host := fmt.Sprintf("TestHost%d", i)
-				_ = backend.AddHost(mac, host)
+				_ = backend.AddHost(types.Host{
+					MAC:  mac,
+					Name: host,
+				})
 			}(i)
 		}
 		wg.Wait()

--- a/pkg/server/storage/testsuite/utils.go
+++ b/pkg/server/storage/testsuite/utils.go
@@ -15,8 +15,9 @@ var testHosts = []types.Host{
 		Name: "TestHost1",
 	},
 	{
-		MAC:  "11:22:33:44:55:66",
-		Name: "TestHost2",
+		MAC:     "11:22:33:44:55:66",
+		Name:    "TestHost2",
+		Address: "host.example.com",
 	},
 	{
 		MAC:  "77:88:99:AA:BB:CC",
@@ -36,7 +37,7 @@ func addHosts(t *testing.T, backend types.StorageBackend) {
 	t.Helper()
 
 	for _, host := range testHosts {
-		err := backend.AddHost(host.MAC, host.Name)
+		err := backend.AddHost(host)
 		require.NoError(t, err, "AddHost failed for %s", host.Name)
 	}
 }

--- a/pkg/server/storage/types/types.go
+++ b/pkg/server/storage/types/types.go
@@ -2,9 +2,9 @@ package types
 
 // Host on the network.
 type Host struct {
-	MAC     string `json:"mac"`
-	Name    string `json:"name"`
-	Address string `json:"address,omitempty"`
+	MAC     string `json:"mac" validate:"required" example:"AA:BB:CC:DD:EE:FF"`
+	Name    string `json:"name" validate:"required" example:"my-host"`
+	Address string `json:"address,omitempty" validate:"optional" example:"host.example.org"`
 }
 
 // StorageBackend is a concurrency safe interface for different methods of storing the configured hosts.

--- a/pkg/server/storage/types/types.go
+++ b/pkg/server/storage/types/types.go
@@ -2,19 +2,20 @@ package types
 
 // Host on the network.
 type Host struct {
-	MAC  string `json:"mac"`
-	Name string `json:"name"`
+	MAC     string `json:"mac"`
+	Name    string `json:"name"`
+	Address string `json:"address,omitempty"`
 }
 
 // StorageBackend is a concurrency safe interface for different methods of storing the configured hosts.
 type StorageBackend interface {
 	// Add a new host, overwrite existing host name if it already exists.
 	// Ensures that the MAC address is unique and uppercase.
-	AddHost(mac, host string) error
+	AddHost(host Host) error
 	// Remove a host, ignore if the host does not exist
 	RemoveHost(mac string) error
 	// Return the host name for a given MAC address, return empty if not found
-	GetHost(mac string) (string, error)
+	GetHost(mac string) (Host, error)
 	// Return all hosts
 	GetHosts() ([]Host, error)
 	// Check if the storage backend is readonly

--- a/pkg/server/storage/valkey/utils.go
+++ b/pkg/server/storage/valkey/utils.go
@@ -1,0 +1,60 @@
+package valkey
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/heathcliff26/go-wol/pkg/server/storage/types"
+)
+
+const (
+	keyName    = "name"
+	keyAddress = "address"
+)
+
+// serialize the Host so it can be stored as a single value in Valkey.
+func serializeHost(host types.Host) string {
+	result := fmt.Sprintf("%s=%s;", keyName, host.Name)
+	if host.Address != "" {
+		result += fmt.Sprintf("%s=%s;", keyAddress, host.Address)
+	}
+	return result
+}
+
+// Deserialize host back into it's parameters.
+func deserializeHost(mac, data string) types.Host {
+	keyvalues := strings.Split(data, ";")
+
+	host := types.Host{
+		MAC: mac,
+	}
+
+	// Maintain compatibility with older versions that only stored the name directly.
+	if len(keyvalues) == 1 {
+		host.Name = keyvalues[0]
+		return host
+	}
+
+	for i, kv := range keyvalues {
+		if i == len(keyvalues)-1 && kv == "" {
+			// Skip the last empty element if it exists
+			continue
+		}
+
+		pair := strings.SplitN(kv, "=", 2)
+		if len(pair) != 2 {
+			slog.Warn("Received invalid host data from valkey, expected pairs key=value separated by semicolons", slog.String("data", data))
+			continue
+		}
+		switch pair[0] {
+		case keyName:
+			host.Name = pair[1]
+		case keyAddress:
+			host.Address = pair[1]
+		default:
+			slog.Warn("Received unknown key in host data from valkey", slog.String("key", pair[0]), slog.String("data", data))
+		}
+	}
+	return host
+}

--- a/pkg/server/storage/valkey/utils_test.go
+++ b/pkg/server/storage/valkey/utils_test.go
@@ -1,0 +1,21 @@
+package valkey
+
+import (
+	"testing"
+
+	"github.com/heathcliff26/go-wol/pkg/server/storage/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeserializeHostBackwardsCompatibility(t *testing.T) {
+	assert := assert.New(t)
+
+	host := types.Host{
+		MAC:  "AA:BB:CC:DD:EE:FF",
+		Name: "TestHost",
+	}
+
+	result := deserializeHost(host.MAC, host.Name)
+	assert.Equal(host, result, "Deserialized host should match original host")
+}

--- a/static/css/bootstrap.css
+++ b/static/css/bootstrap.css
@@ -1227,6 +1227,10 @@ button:not(:disabled),
   font-size: 1rem !important;
 }
 
+.fw-light {
+  font-weight: 300 !important;
+}
+
 .fw-bold {
   font-weight: 700 !important;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -37,12 +37,19 @@
                             <li class="list-group-item shadow">
                                 <div class="row">
                                     <div class="col-md-6">
-                                        <p class="fs-4 fw-bold">{{.Name}}</p>
+                                        <p class="fs-4 fw-bold" id="{{.MAC}}.Name">{{.Name}}</p>
                                     </div>
                                     <div class="col-md-6">
-                                        <p class="fs-6 p-2">{{.MAC}}</p>
+                                        <p class="fs-6 p-2" id="{{.MAC}}.MAC">{{.MAC}}</p>
                                     </div>
                                 </div>
+                                {{if .Address}}
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <p class="fs-6 fw-light" id="{{.MAC}}.Address">{{.Address}}</p>
+                                    </div>
+                                </div>
+                                {{end}}
                                 <div class="row">
                                     <div class="col">
                                         <button type="button" class="btn btn-primary w-100" onclick="wake('{{.MAC}}', '{{.Name}}');" aria-label="Wake {{.Name}}">Wake</button>
@@ -112,6 +119,10 @@
                         <div class="mb-3">
                             <label for="macAddress" class="form-label">MAC Address</label>
                             <input type="text" class="form-control" id="macAddress" required aria-label="The MAC address of the new host" oninput="formatAndValidateMAC(this)">
+                        </div>
+                        <div class="mb-3">
+                            <label for="address" class="form-label">Address (Optional)</label>
+                            <input type="text" class="form-control" id="address" aria-label="(Optional) Address of the host to check if it is online">
                         </div>
                     </div>
                     <div class="modal-footer">

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -30,8 +30,15 @@ async function addHost() {
 
     modal.hide();
     try {
-        const response = await fetch('/api/v1/hosts/'+macAddr+"/"+name, {
+        const response = await fetch('/api/v1/hosts', {
             method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                MAC: macAddr,
+                Name: name
+            })
         });
 
         const responseBody = await response.json();

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -27,6 +27,15 @@ async function wakeCustom() {
 async function addHost() {
     const name = document.getElementById('hostName').value;
     const macAddr = document.getElementById('macAddress').value;
+    const address = document.getElementById('address').value;
+
+    const host = {
+        MAC: macAddr,
+        Name: name
+    }
+    if (address != "") {
+        host.Address = address;
+    }
 
     modal.hide();
     try {
@@ -35,10 +44,7 @@ async function addHost() {
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({
-                MAC: macAddr,
-                Name: name
-            })
+            body: JSON.stringify(host)
         });
 
         const responseBody = await response.json();

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,11 +1,21 @@
 basePath: /api/v1
+consumes:
+- application/json
 definitions:
   types.Host:
     properties:
+      address:
+        example: host.example.org
+        type: string
       mac:
+        example: AA:BB:CC:DD:EE:FF
         type: string
       name:
+        example: my-host
         type: string
+    required:
+    - mac
+    - name
     type: object
   v1.Response:
     properties:
@@ -40,6 +50,37 @@ paths:
           schema:
             $ref: '#/definitions/v1.Response'
       summary: Get hosts
+    put:
+      consumes:
+      - application/json
+      description: Add a new host to the known hosts
+      parameters:
+      - description: New host to add
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/types.Host'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "400":
+          description: Invalid MAC address or hostname
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "403":
+          description: Storage is readonly
+          schema:
+            $ref: '#/definitions/v1.Response'
+        "500":
+          description: Failed to add host
+          schema:
+            $ref: '#/definitions/v1.Response'
+      summary: Add new host
   /hosts/{macAddr}:
     delete:
       description: Remove a host from the list of known hosts
@@ -69,40 +110,6 @@ paths:
           schema:
             $ref: '#/definitions/v1.Response'
       summary: Remove host
-  /hosts/{macAddr}/{name}:
-    put:
-      description: Add a new host to the known hosts
-      parameters:
-      - description: MAC address of the host
-        in: path
-        name: macAddr
-        required: true
-        type: string
-      - description: Name of the host
-        in: path
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: ok
-          schema:
-            $ref: '#/definitions/v1.Response'
-        "400":
-          description: Invalid MAC address or hostname
-          schema:
-            $ref: '#/definitions/v1.Response'
-        "403":
-          description: Storage is readonly
-          schema:
-            $ref: '#/definitions/v1.Response'
-        "500":
-          description: Failed to add host
-          schema:
-            $ref: '#/definitions/v1.Response'
-      summary: Add new host
   /wake/{macAddr}:
     get:
       description: Send a magic packet to the specified MAC address


### PR DESCRIPTION
Add the optional attribut address to hosts. This will later allow to display the status of the hosts.

This breaks the api by requiring a json body for the parameters when adding a new host.

It changes how valkey stores the value, making hosts saved by this version incompatible with older versions.