### PR TITLE
Dockerfile: Use user and group nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM scratch AS final-stage
 
 COPY --from=build-stage /app/bin/go-wol /go-wol
 
-USER 1001
+USER 65534:65534
 
 WORKDIR /data
 VOLUME /data


### PR DESCRIPTION
Instead of 1001, which could exist on the target system and have some privileges, use nobody to guarantee that the user has no privileges.

When using file as storage for hosts, the permissions/owner of the file should be changed when upgrading.